### PR TITLE
Access the admin page

### DIFF
--- a/refactoring/Brokurly_v2/Brokurly_v2/settings.py
+++ b/refactoring/Brokurly_v2/Brokurly_v2/settings.py
@@ -164,6 +164,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 REST_USE_JWT = True
 
+SITE_ID = 1
 
 AUTH_USER_MODEL = 'users.CustomAccounts'
 


### PR DESCRIPTION
```python
settings.py

SITE_ID = 1
```
```python
users > admin.py

from django.contrib import admin
from users.models import CustomAccounts

admin.site.register(CustomAccounts)
```
```python
superuser 생성

python manage.py createsuperuser
```
위와 같이 세팅하면 DRF에서 제공하는 admin page 로 접속 할 수 있다.